### PR TITLE
Enable GPU pipeline to read BLOSC-compressed data

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - conda-forge::click
   - conda-forge::cupy
   - conda-forge::h5py[build=mpi*]
+  - conda-forge::hdf5plugin
   - conda-forge::mpi4py
   - conda-forge::numpy
   - conda-forge::nvtx

--- a/src/htto/gpu_pipeline.py
+++ b/src/htto/gpu_pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import cupy as cp
 import h5py as h5
+import hdf5plugin
 import numpy as np
 import tomopy
 from larix.methods.misc_gpu import MEDIAN_FILT_GPU


### PR DESCRIPTION
Luckily there were very few changes needed for this, just to install a package which provides BLOSC compression, and then the import lets h5py take care of decompression auto-magically!